### PR TITLE
minor typo fix in docs

### DIFF
--- a/packages/website/README.md
+++ b/packages/website/README.md
@@ -20,7 +20,7 @@ npm run brisk dev
 To produce a static build of the website that can be statically hosted:
 
 ```shell
-npm run brisk build && npm run brisk export:
+npm run brisk build && npm run brisk export
 ```
 
 ## Organising your documentation


### PR DESCRIPTION
update the command to be `export` from `export:`