### PR TITLE
Initial commit - Router in brisk running parcel2

### DIFF
--- a/package.json
+++ b/package.json
@@ -126,6 +126,8 @@
     "react-addons-text-content": "^0.0.4",
     "react-dom": "^16.8.4",
     "react-markdown": "^2.5.0",
+    "react-router": "^4.3.1",
+    "react-router-dom": "^4.3.1",
     "remark-frontmatter": "^1.3.2",
     "remark-parse": "^6.0.3",
     "resolve": "^1.10.0",

--- a/packages/website/__fixtures__/typescript-project/typescript-package/component.tsx
+++ b/packages/website/__fixtures__/typescript-project/typescript-package/component.tsx
@@ -1,5 +1,5 @@
 // This example demonstrates a react component written in tsx
-import * as React from 'react';
+import React from 'react';
 
 export interface HelloProps {
   compiler: string;

--- a/packages/website/__tests__/components/switch-link.test.tsx
+++ b/packages/website/__tests__/components/switch-link.test.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { mount } from 'enzyme';
-
 import SwitchLink from '../../src/components/switch-link';
 
 const children = 'some text';
@@ -57,12 +56,13 @@ describe('<SwitchLink />', () => {
     expect(wrapper.find('ShortcutIcon')).toHaveLength(0);
   });
 
-  it('renders a Link component for relative links', () => {
-    const wrapper = mount(<SwitchLink {...initialProps} />);
-    const component = wrapper.find('Link');
-
-    expect(component.exists()).toBeTruthy();
-    expect(component.text()).toEqual(children);
-    expect(component.prop('href')).toEqual(initialProps.href);
-  });
+  // TODO: Need to re-test when re-implement the relative links in SwitchLink
+  // it('renders a Link component for relative links', () => {
+  //   const wrapper = mount(<SwitchLink {...initialProps} />);
+  //   const component = wrapper.find('Link');
+  //
+  //   expect(component.exists()).toBeTruthy();
+  //   expect(component.text()).toEqual(children);
+  //   expect(component.prop('href')).toEqual(initialProps.href);
+  // });
 });

--- a/packages/website/default-pages/healthcheck.tsx
+++ b/packages/website/default-pages/healthcheck.tsx
@@ -1,3 +1,3 @@
-import * as React from 'react';
+import React from 'react';
 
 export default () => <div>OK</div>;

--- a/packages/website/default-pages/index.tsx
+++ b/packages/website/default-pages/index.tsx
@@ -1,6 +1,7 @@
-import * as React from 'react';
+import React from 'react';
 import styled from 'styled-components';
 import debounce from 'lodash.debounce';
+import { Route } from 'react-router';
 
 import LinkIcon from '@atlaskit/icon/glyph/link';
 import MediaDocIcon from '@atlaskit/icon/glyph/media-services/document';
@@ -137,4 +138,5 @@ class HomePage extends React.Component {
   }
 }
 
-export default HomePage;
+// export default HomePage;
+export default () => <Route exact path="/" component={HomePage} />;

--- a/packages/website/default-pages/packages.tsx
+++ b/packages/website/default-pages/packages.tsx
@@ -1,8 +1,8 @@
-import * as React from 'react';
+import React from 'react';
 import Table from '@atlaskit/dynamic-table';
 
-import styled from 'styled-components';
-import Link from 'next/link';
+// import styled from 'styled-components';
+import { NavLink, Route } from 'react-router-dom';
 import { gridSize as gridSizeFn } from '@atlaskit/theme';
 import titleCase from 'title-case';
 
@@ -88,25 +88,23 @@ const renderRow = ({
       {
         key: packageId,
         content: (
-          <RowCell>
-            <Link href={homePath}>
-              <a>{display}</a>
-            </Link>
-          </RowCell>
+          <div>
+            <NavLink to={homePath}>{display}</NavLink>
+          </div>
         ),
       },
       {
         key: 'description',
-        content: <RowCell>{metaData.description}</RowCell>,
+        content: <div>{metaData.description}</div>,
       },
       {
         key: 'version',
         shouldTruncate: true,
-        content: <RowCell>{metaData.version}</RowCell>,
+        content: <div>{metaData.version}</div>,
       },
       {
         key: 'maintainers',
-        content: <RowCell>{MaintainersToString(metaData.maintainers)}</RowCell>,
+        content: <div>{MaintainersToString(metaData.maintainers)}</div>,
       },
     ],
   };
@@ -129,10 +127,10 @@ const PackagesList = () => (
 );
 
 // Tabular data
-const RowCell = styled.div`
-  padding-bottom: ${gridSize}px;
-  padding-top: ${gridSize}px;
-`;
+// const RowCell = styled.div`
+//   padding-bottom: ${gridSize}px;
+//   padding-top: ${gridSize}px;
+// `;
 
 const Index = () => (
   <>
@@ -144,4 +142,5 @@ const Index = () => (
     </NavigationWrapper>
   </>
 );
-export default Index;
+
+export default () => <Route path="/packages" component={Index} />;

--- a/packages/website/default-pages/testpackage.tsx
+++ b/packages/website/default-pages/testpackage.tsx
@@ -1,0 +1,6 @@
+import React from 'react';
+import { Route } from 'react-router-dom';
+
+const view = () => <div>This is a test page for routing</div>;
+
+export default () => <Route path="/testpackage" component={view} />;

--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -109,6 +109,8 @@
     "react": "^16.8.4",
     "react-addons-text-content": "^0.0.4",
     "react-dom": "^16.8.4",
+    "react-router": "^4.3.1",
+    "react-router-dom": "^4.3.1",
     "remark-frontmatter": "^1.3.2",
     "remark-parse": "^6.0.3",
     "resolve": "^1.10.0",

--- a/packages/website/src/_app.js
+++ b/packages/website/src/_app.js
@@ -3,6 +3,7 @@
 
 import React from 'react';
 import ReactDOM from 'react-dom';
+import { BrowserRouter, Switch } from 'react-router-dom';
 import Meta, { metadata } from './components/meta-context';
 
 const pageEntryModule = parcelRequire(__BRISK_ENTRY_ASSET_ID);
@@ -11,12 +12,18 @@ const PageEntryComponent =
     ? pageEntryModule.default
     : pageEntryModule;
 
+console.log(PageEntryComponent);
+
 // eslint-disable-next-line react/prefer-stateless-function
 class App extends React.Component {
   render() {
     return (
       <Meta.Provider value={metadata}>
-        <PageEntryComponent />
+        <BrowserRouter>
+          <Switch>
+            <PageEntryComponent />
+          </Switch>
+        </BrowserRouter>
       </Meta.Provider>
     );
   }

--- a/packages/website/src/bin/page-generator/__snapshots__/test.js.snap
+++ b/packages/website/src/bin/page-generator/__snapshots__/test.js.snap
@@ -2,268 +2,321 @@
 
 exports[`Additional items in the docs tests creates pages for each markdown file in docs and guides folder 1`] = `
 import React from 'react';
+import { Route } from 'react-router-dom';
 import Component from '../../../jest-fixture/docs/testdoc.md';
 import Wrapper from '../../../jest-fixture/project-docs';
 
-export default () => (
+const view = () => (
   <Wrapper data={{"key":"docs","pagePath":"docs/testdoc.js","pageTitle":"Testdoc"}}>
       <Component />
   </Wrapper>
 );
+
+export default () => <Route path='/docs/testdoc' component={view}/>
 `;
 
 exports[`Additional items in the docs tests creates pages for each markdown file in docs and guides folder 2`] = `
 import React from 'react';
+import { Route } from 'react-router-dom';
 import Component from '../../../jest-fixture/guides/testguide.md';
 import Wrapper from '../../../jest-fixture/project-docs';
 
-export default () => (
+const view = () => (
   <Wrapper data={{"key":"guides","pagePath":"guides/testguide.js","pageTitle":"Testguide"}}>
       <Component />
   </Wrapper>
 );
+
+export default () => <Route path='/guides/testguide' component={view}/>
 `;
 
 exports[`Generate pages docs pages generation creates an index/home page for each level of nesting 1`] = `
 import React from 'react';
 import Wrapper from '../../../jest-fixture/documents-index';
 
-export default () => (
+const view = () => (
   <Wrapper data={{"key":"docs","pagePath":"docs/index.js","pageTitle":"docs","pageType":"docs"}} />
 );
+export default () => <Route path='/docs' component={view}/>
 `;
 
 exports[`Generate pages docs pages generation creates an index/home page for each level of nesting 2`] = `
 import React from 'react';
 import Wrapper from '../../../../jest-fixture/item-list';
 
-export default () => (
+const view = () => (
   <Wrapper data={{"key":"docs","id":"doc-3","children":[{"id":"doc-3-1","meta":{"title":"Doc 3 1","readingTime":"1 second"},"pagePath":"doc-3/doc-3-1"},{"id":"doc-3-2","meta":{"title":"Doc 3 2"},"pagePath":"doc-3/doc-3-2"}],"pagePath":"docs/doc-3/index.js","pageTitle":"Documents","pageType":"docs"}} />
 );
+export default () => <Route path='/docs/doc-3' component={view}/>
 `;
 
 exports[`Generate pages docs pages generation creates an index/home page for each level of nesting 3`] = `
 import React from 'react';
 import Wrapper from '../../../../../jest-fixture/item-list';
 
-export default () => (
+const view = () => (
   <Wrapper data={{"key":"docs","id":"doc-3-2","children":[{"id":"doc-3-2-1","meta":{"title":"Doc 3 2 1","usefulness":"yes"},"pagePath":"doc-3-2/doc-3-2-1"}],"pagePath":"docs/doc-3/doc-3-2/index.js","pageTitle":"Documents","pageType":"docs"}} />
 );
+export default () => <Route path='/docs/doc-3/doc-3-2' component={view}/>
 `;
 
 exports[`Generate pages docs pages generation creates pages for each markdown file 1`] = `
 import React from 'react';
+import { Route } from 'react-router-dom';
 import Component from '../../../jest-fixture/docs/doc-1.md';
 import Wrapper from '../../../jest-fixture/project-docs';
 
-export default () => (
+const view = () => (
   <Wrapper data={{"key":"docs","pagePath":"docs/doc-1.js","pageTitle":"Document One"}}>
       <Component />
   </Wrapper>
 );
+
+export default () => <Route path='/docs/doc-1' component={view}/>
 `;
 
 exports[`Generate pages docs pages generation creates pages for each markdown file 2`] = `
 import React from 'react';
+import { Route } from 'react-router-dom';
 import Component from '../../../jest-fixture/docs/doc-2.md';
 import Wrapper from '../../../jest-fixture/project-docs';
 
-export default () => (
+const view = () => (
   <Wrapper data={{"key":"docs","pagePath":"docs/doc-2.js","pageTitle":"Doc 2"}}>
       <Component />
   </Wrapper>
 );
+
+export default () => <Route path='/docs/doc-2' component={view}/>
 `;
 
 exports[`Generate pages docs pages generation creates pages for each markdown file 3`] = `
 import React from 'react';
+import { Route } from 'react-router-dom';
 import Component from '../../../../jest-fixture/docs/doc-3/doc-3-1.md';
 import Wrapper from '../../../../jest-fixture/project-docs';
 
-export default () => (
+const view = () => (
   <Wrapper data={{"key":"docs","pagePath":"docs/doc-3/doc-3-1.js","pageTitle":"Doc 3 1"}}>
       <Component />
   </Wrapper>
 );
+
+export default () => <Route path='/docs/doc-3/doc-3-1' component={view}/>
 `;
 
 exports[`Generate pages docs pages generation creates pages for each markdown file 4`] = `
 import React from 'react';
+import { Route } from 'react-router-dom';
 import Component from '../../../../../jest-fixture/docs/doc-3/doc-3-2/doc-3-2-1.md';
 import Wrapper from '../../../../../jest-fixture/project-docs';
 
-export default () => (
+const view = () => (
   <Wrapper data={{"key":"docs","pagePath":"docs/doc-3/doc-3-2/doc-3-2-1.js","pageTitle":"Doc 3 2 1"}}>
       <Component />
   </Wrapper>
 );
+
+export default () => <Route path='/docs/doc-3/doc-3-2/doc-3-2-1' component={view}/>
 `;
 
 exports[`Generate pages docs pages generation with differing name and path creates pages for each markdown file based on docsPath rather than name 1`] = `
 import React from 'react';
+import { Route } from 'react-router-dom';
 import Component from '../../../jest-fixture/guides/testguide.md';
 import Wrapper from '../../../jest-fixture/project-docs';
 
-export default () => (
+const view = () => (
   <Wrapper data={{"key":"cool-doc-stuff","pagePath":"guides/testguide.js","pageTitle":"Testguide"}}>
       <Component />
   </Wrapper>
 );
+
+export default () => <Route path='/guides/testguide' component={view}/>
 `;
 
 exports[`Generate pages package pages generation creates a home page per package 1`] = `
 import React from 'react';
+import { Route } from 'react-router-dom';
 import Component from '../../../../jest-fixture/packages/mock-package1/README.md';
 import Wrapper from '../../../../jest-fixture/package-home';
 
-export default () => (
+const view = () => (
   <Wrapper data={{"id":"mock-package-1","packageName":"mock-package-1","description":"This is a mock package to be used for doc website","name":"mock-package-1","version":"1.0.0","customPackageFields":["description","maintainers","name","repository","version"],"pagePath":"packages/mock-package-1/index.js","pageTitle":"Mock Package 1"}}>
       <Component />
   </Wrapper>
 );
+
+export default () => <Route path='/packages/mock-package-1' component={view}/>
 `;
 
 exports[`Generate pages package pages generation creates a home page per package 2`] = `
 import React from 'react';
+import { Route } from 'react-router-dom';
 import Component from '../../../../jest-fixture/packages/mock-package2/README.md';
 import Wrapper from '../../../../jest-fixture/package-home';
 
-export default () => (
+const view = () => (
   <Wrapper data={{"id":"mock-package-2","packageName":"mock-package-2","description":"This is a mock package2 to be used for doc website","name":"mock-package-2","version":"1.0.0","customPackageFields":["description","maintainers","name","repository","version"],"pagePath":"packages/mock-package-2/index.js","pageTitle":"Mock Package 2"}}>
       <Component />
   </Wrapper>
 );
+
+export default () => <Route path='/packages/mock-package-2' component={view}/>
 `;
 
 exports[`Generate pages package pages generation creates a home page per package 3`] = `
 import React from 'react';
+import { Route } from 'react-router-dom';
 import Component from '../../../../jest-fixture/packages/mock-package2/README.md';
 import Wrapper from '../../../../jest-fixture/package-home';
 
-export default () => (
+const view = () => (
   <Wrapper data={{"id":"mock-package-2","packageName":"mock-package-2","description":"This is a mock package2 to be used for doc website","name":"mock-package-2","version":"1.0.0","customPackageFields":["description","maintainers","name","repository","version"],"pagePath":"packages/mock-package-2/index.js","pageTitle":"Mock Package 2"}}>
       <Component />
   </Wrapper>
 );
+
+export default () => <Route path='/packages/mock-package-2' component={view}/>
 `;
 
 exports[`Generate pages package pages generation creates docs pages for each package: mock-package-1 1`] = `
 import React from 'react';
 import Wrapper from '../../../../../jest-fixture/item-list';
 
-export default () => (
+const view = () => (
   <Wrapper data={{"id":"mock-package-1","packageName":"mock-package-1","pagePath":"packages/mock-package-1/docs/index.js","pageTitle":"Documents","pageType":"docs"}} />
 );
+export default () => <Route path='/packages/mock-package-1/docs' component={view}/>
 `;
 
 exports[`Generate pages package pages generation creates docs pages for each package: mock-package-1 2`] = `
 import React from 'react';
+import { Route } from 'react-router-dom';
 import Component from '../../../../../jest-fixture/packages/mock-package1/docs/extended-info.md';
 import Wrapper from '../../../../../jest-fixture/package-docs';
 
-export default () => (
+const view = () => (
   <Wrapper data={{"id":"mock-package-1","packageName":"mock-package-1","pagePath":"packages/mock-package-1/docs/extended-info.js","pageTitle":"Extended Information"}}>
       <Component />
   </Wrapper>
 );
+
+export default () => <Route path='/packages/mock-package-1/docs/extended-info' component={view}/>
 `;
 
 exports[`Generate pages package pages generation creates docs pages for each package: mock-package-1 3`] = `
 import React from 'react';
+import { Route } from 'react-router-dom';
 import Component from '../../../../../jest-fixture/packages/mock-package1/docs/special-usecase.mdx';
 import Wrapper from '../../../../../jest-fixture/package-docs';
 
-export default () => (
+const view = () => (
   <Wrapper data={{"id":"mock-package-1","packageName":"mock-package-1","pagePath":"packages/mock-package-1/docs/special-usecase.js","pageTitle":"Special Usecase"}}>
       <Component />
   </Wrapper>
 );
+
+export default () => <Route path='/packages/mock-package-1/docs/special-usecase' component={view}/>
 `;
 
 exports[`Generate pages package pages generation creates docs pages for each package: mock-package-2 1`] = `
 import React from 'react';
 import Wrapper from '../../../../../jest-fixture/item-list';
 
-export default () => (
+const view = () => (
   <Wrapper data={{"id":"mock-package-2","packageName":"mock-package-2","pagePath":"packages/mock-package-2/docs/index.js","pageTitle":"Documents","pageType":"docs"}} />
 );
+export default () => <Route path='/packages/mock-package-2/docs' component={view}/>
 `;
 
 exports[`Generate pages package pages generation creates docs pages for each package: mock-package-2 2`] = `
 import React from 'react';
+import { Route } from 'react-router-dom';
 import Component from '../../../../../jest-fixture/packages/mock-package2/docs/extended-info.md';
 import Wrapper from '../../../../../jest-fixture/package-docs';
 
-export default () => (
+const view = () => (
   <Wrapper data={{"id":"mock-package-2","packageName":"mock-package-2","pagePath":"packages/mock-package-2/docs/extended-info.js","pageTitle":"Extended Info"}}>
       <Component />
   </Wrapper>
 );
+
+export default () => <Route path='/packages/mock-package-2/docs/extended-info' component={view}/>
 `;
 
 exports[`Generate pages package pages generation creates docs pages for each package: mock-package-2 3`] = `
 import React from 'react';
+import { Route } from 'react-router-dom';
 import Component from '../../../../../jest-fixture/packages/mock-package2/docs/special-usecase.mdx';
 import Wrapper from '../../../../../jest-fixture/package-docs';
 
-export default () => (
+const view = () => (
   <Wrapper data={{"id":"mock-package-2","packageName":"mock-package-2","pagePath":"packages/mock-package-2/docs/special-usecase.js","pageTitle":"Special Usecase"}}>
       <Component />
   </Wrapper>
 );
+
+export default () => <Route path='/packages/mock-package-2/docs/special-usecase' component={view}/>
 `;
 
 exports[`Generate pages package pages generation creates docs pages for each package: mock-package-3 1`] = `
 import React from 'react';
 import Wrapper from '../../../../../jest-fixture/item-list';
 
-export default () => (
+const view = () => (
   <Wrapper data={{"id":"mock-package-3","packageName":"mock-package-3","pagePath":"packages/mock-package-3/docs/index.js","pageTitle":"Documents","pageType":"docs"}} />
 );
+export default () => <Route path='/packages/mock-package-3/docs' component={view}/>
 `;
 
 exports[`Generate pages package pages generation creates docs pages for each package: mock-package-3 2`] = `
 import React from 'react';
+import { Route } from 'react-router-dom';
 import Component from '../../../../../jest-fixture/packages/mock-package3/docs/extended-info.md';
 import Wrapper from '../../../../../jest-fixture/package-docs';
 
-export default () => (
+const view = () => (
   <Wrapper data={{"id":"mock-package-3","packageName":"mock-package-3","pagePath":"packages/mock-package-3/docs/extended-info.js","pageTitle":"Extended Info"}}>
       <Component />
   </Wrapper>
 );
+
+export default () => <Route path='/packages/mock-package-3/docs/extended-info' component={view}/>
 `;
 
 exports[`Generate pages package pages generation creates docs pages for each package: mock-package-3 3`] = `
 import React from 'react';
+import { Route } from 'react-router-dom';
 import Component from '../../../../../jest-fixture/packages/mock-package3/docs/special-usecase.mdx';
 import Wrapper from '../../../../../jest-fixture/package-docs';
 
-export default () => (
+const view = () => (
   <Wrapper data={{"id":"mock-package-3","packageName":"mock-package-3","pagePath":"packages/mock-package-3/docs/special-usecase.js","pageTitle":"Special Usecase"}}>
       <Component />
   </Wrapper>
 );
+
+export default () => <Route path='/packages/mock-package-3/docs/special-usecase' component={view}/>
 `;
 
 exports[`Generate pages package pages generation creates examples pages for each package 1`] = `
 import React from 'react';
 import Wrapper from '../../../../../jest-fixture/item-list';
 
-export default () => (
+const view = () => (
   <Wrapper data={{"id":"mock-package-1","packageName":"mock-package-1","pagePath":"packages/mock-package-1/examples/index.js","pageTitle":"Examples","pageType":"examples"}} />
 );
+export default () => <Route path='/packages/mock-package-1/examples' component={view}/>
 `;
 
 exports[`Generate pages package pages generation creates examples pages for each package 2`] = `
 import React from 'react';
-import dynamic from 'next/dynamic';
 import fileContents from '!!raw-loader!../../../../../jest-fixture/packages/mock-package1/examples/example1';
 import Wrapper from '../../../../../jest-fixture/package-example';
+import * as Components from '../../../../../jest-fixture/packages/mock-package1/examples/example1';
 
-const DynamicComponent = dynamic(import('../../../../../jest-fixture/packages/mock-package1/examples/example1')
-.then(Components => {
-return () => ( 
+const view = () => ( 
 <Wrapper data={{"id":"mock-package-1","packageName":"mock-package-1","isolatedPath":"/packages/mock-package-1/examples/isolated/example1","pageTitle":"Example1"}} fileContents={fileContents}>
       {
         [{ 
@@ -281,20 +334,17 @@ return () => (
         ]
       }
   </Wrapper>
-  )
-}));
-export default () => <DynamicComponent/>
+  );
+export default () => <Route path='//packages/mock-package-1/examples/isolated/example1' component={view}/> 
 `;
 
 exports[`Generate pages package pages generation creates examples pages for each package 3`] = `
 import React from 'react';
-import dynamic from 'next/dynamic';
 import fileContents from '!!raw-loader!../../../../../jest-fixture/packages/mock-package1/examples/example2';
 import Wrapper from '../../../../../jest-fixture/package-example';
+import * as Components from '../../../../../jest-fixture/packages/mock-package1/examples/example2';
 
-const DynamicComponent = dynamic(import('../../../../../jest-fixture/packages/mock-package1/examples/example2')
-.then(Components => {
-return () => ( 
+const view = () => ( 
 <Wrapper data={{"id":"mock-package-1","packageName":"mock-package-1","isolatedPath":"/packages/mock-package-1/examples/isolated/example2","pageTitle":"Example2"}} fileContents={fileContents}>
       {
         [{ 
@@ -312,20 +362,17 @@ return () => (
         ]
       }
   </Wrapper>
-  )
-}));
-export default () => <DynamicComponent/>
+  );
+export default () => <Route path='//packages/mock-package-1/examples/isolated/example2' component={view}/> 
 `;
 
 exports[`Generate pages package pages generation creates examples pages for each package 4`] = `
 import React from 'react';
-import dynamic from 'next/dynamic';
 import fileContents from '!!raw-loader!../../../../../jest-fixture/packages/mock-package1/examples/example3';
 import Wrapper from '../../../../../jest-fixture/package-example';
+import * as Components from '../../../../../jest-fixture/packages/mock-package1/examples/example3';
 
-const DynamicComponent = dynamic(import('../../../../../jest-fixture/packages/mock-package1/examples/example3')
-.then(Components => {
-return () => ( 
+const view = () => ( 
 <Wrapper data={{"id":"mock-package-1","packageName":"mock-package-1","isolatedPath":"/packages/mock-package-1/examples/isolated/example3","pageTitle":"Example3"}} fileContents={fileContents}>
       {
         [{ 
@@ -343,29 +390,27 @@ return () => (
         ]
       }
   </Wrapper>
-  )
-}));
-export default () => <DynamicComponent/>
+  );
+export default () => <Route path='//packages/mock-package-1/examples/isolated/example3' component={view}/> 
 `;
 
 exports[`Generate pages package pages generation creates examples pages for each package 5`] = `
 import React from 'react';
 import Wrapper from '../../../../../jest-fixture/item-list';
 
-export default () => (
+const view = () => (
   <Wrapper data={{"id":"mock-package-2","packageName":"mock-package-2","pagePath":"packages/mock-package-2/examples/index.js","pageTitle":"Examples","pageType":"examples"}} />
 );
+export default () => <Route path='/packages/mock-package-2/examples' component={view}/>
 `;
 
 exports[`Generate pages package pages generation creates examples pages for each package 6`] = `
 import React from 'react';
-import dynamic from 'next/dynamic';
 import fileContents from '!!raw-loader!../../../../../jest-fixture/packages/mock-package2/examples/example1';
 import Wrapper from '../../../../../jest-fixture/package-example';
+import * as Components from '../../../../../jest-fixture/packages/mock-package2/examples/example1';
 
-const DynamicComponent = dynamic(import('../../../../../jest-fixture/packages/mock-package2/examples/example1')
-.then(Components => {
-return () => ( 
+const view = () => ( 
 <Wrapper data={{"id":"mock-package-2","packageName":"mock-package-2","isolatedPath":"/packages/mock-package-2/examples/isolated/example1","pageTitle":"Example1"}} fileContents={fileContents}>
       {
         [{ 
@@ -383,20 +428,17 @@ return () => (
         ]
       }
   </Wrapper>
-  )
-}));
-export default () => <DynamicComponent/>
+  );
+export default () => <Route path='//packages/mock-package-2/examples/isolated/example1' component={view}/> 
 `;
 
 exports[`Generate pages package pages generation creates examples pages for each package 7`] = `
 import React from 'react';
-import dynamic from 'next/dynamic';
 import fileContents from '!!raw-loader!../../../../../jest-fixture/packages/mock-package2/examples/example2';
 import Wrapper from '../../../../../jest-fixture/package-example';
+import * as Components from '../../../../../jest-fixture/packages/mock-package2/examples/example2';
 
-const DynamicComponent = dynamic(import('../../../../../jest-fixture/packages/mock-package2/examples/example2')
-.then(Components => {
-return () => ( 
+const view = () => ( 
 <Wrapper data={{"id":"mock-package-2","packageName":"mock-package-2","isolatedPath":"/packages/mock-package-2/examples/isolated/example2","pageTitle":"Example2"}} fileContents={fileContents}>
       {
         [{ 
@@ -414,20 +456,17 @@ return () => (
         ]
       }
   </Wrapper>
-  )
-}));
-export default () => <DynamicComponent/>
+  );
+export default () => <Route path='//packages/mock-package-2/examples/isolated/example2' component={view}/> 
 `;
 
 exports[`Generate pages package pages generation creates examples pages for each package 8`] = `
 import React from 'react';
-import dynamic from 'next/dynamic';
 import fileContents from '!!raw-loader!../../../../../jest-fixture/packages/mock-package2/examples/example3';
 import Wrapper from '../../../../../jest-fixture/package-example';
+import * as Components from '../../../../../jest-fixture/packages/mock-package2/examples/example3';
 
-const DynamicComponent = dynamic(import('../../../../../jest-fixture/packages/mock-package2/examples/example3')
-.then(Components => {
-return () => ( 
+const view = () => ( 
 <Wrapper data={{"id":"mock-package-2","packageName":"mock-package-2","isolatedPath":"/packages/mock-package-2/examples/isolated/example3","pageTitle":"Example3"}} fileContents={fileContents}>
       {
         [{ 
@@ -445,29 +484,27 @@ return () => (
         ]
       }
   </Wrapper>
-  )
-}));
-export default () => <DynamicComponent/>
+  );
+export default () => <Route path='//packages/mock-package-2/examples/isolated/example3' component={view}/> 
 `;
 
 exports[`Generate pages package pages generation creates examples pages for each package 9`] = `
 import React from 'react';
 import Wrapper from '../../../../../jest-fixture/item-list';
 
-export default () => (
+const view = () => (
   <Wrapper data={{"id":"mock-package-3","packageName":"mock-package-3","pagePath":"packages/mock-package-3/examples/index.js","pageTitle":"Examples","pageType":"examples"}} />
 );
+export default () => <Route path='/packages/mock-package-3/examples' component={view}/>
 `;
 
 exports[`Generate pages package pages generation creates examples pages for each package 10`] = `
 import React from 'react';
-import dynamic from 'next/dynamic';
 import fileContents from '!!raw-loader!../../../../../jest-fixture/packages/mock-package3/examples/example1';
 import Wrapper from '../../../../../jest-fixture/package-example';
+import * as Components from '../../../../../jest-fixture/packages/mock-package3/examples/example1';
 
-const DynamicComponent = dynamic(import('../../../../../jest-fixture/packages/mock-package3/examples/example1')
-.then(Components => {
-return () => ( 
+const view = () => ( 
 <Wrapper data={{"id":"mock-package-3","packageName":"mock-package-3","isolatedPath":"/packages/mock-package-3/examples/isolated/example1","pageTitle":"Example1"}} fileContents={fileContents}>
       {
         [{ 
@@ -485,20 +522,17 @@ return () => (
         ]
       }
   </Wrapper>
-  )
-}));
-export default () => <DynamicComponent/>
+  );
+export default () => <Route path='//packages/mock-package-3/examples/isolated/example1' component={view}/> 
 `;
 
 exports[`Generate pages package pages generation creates examples pages for each package 11`] = `
 import React from 'react';
-import dynamic from 'next/dynamic';
 import fileContents from '!!raw-loader!../../../../../jest-fixture/packages/mock-package3/examples/example2';
 import Wrapper from '../../../../../jest-fixture/package-example';
+import * as Components from '../../../../../jest-fixture/packages/mock-package3/examples/example2';
 
-const DynamicComponent = dynamic(import('../../../../../jest-fixture/packages/mock-package3/examples/example2')
-.then(Components => {
-return () => ( 
+const view = () => ( 
 <Wrapper data={{"id":"mock-package-3","packageName":"mock-package-3","isolatedPath":"/packages/mock-package-3/examples/isolated/example2","pageTitle":"Example2"}} fileContents={fileContents}>
       {
         [{ 
@@ -516,20 +550,17 @@ return () => (
         ]
       }
   </Wrapper>
-  )
-}));
-export default () => <DynamicComponent/>
+  );
+export default () => <Route path='//packages/mock-package-3/examples/isolated/example2' component={view}/> 
 `;
 
 exports[`Generate pages package pages generation creates examples pages for each package 12`] = `
 import React from 'react';
-import dynamic from 'next/dynamic';
 import fileContents from '!!raw-loader!../../../../../jest-fixture/packages/mock-package3/examples/example3';
 import Wrapper from '../../../../../jest-fixture/package-example';
+import * as Components from '../../../../../jest-fixture/packages/mock-package3/examples/example3';
 
-const DynamicComponent = dynamic(import('../../../../../jest-fixture/packages/mock-package3/examples/example3')
-.then(Components => {
-return () => ( 
+const view = () => ( 
 <Wrapper data={{"id":"mock-package-3","packageName":"mock-package-3","isolatedPath":"/packages/mock-package-3/examples/isolated/example3","pageTitle":"Example3"}} fileContents={fileContents}>
       {
         [{ 
@@ -547,43 +578,51 @@ return () => (
         ]
       }
   </Wrapper>
-  )
-}));
-export default () => <DynamicComponent/>
+  );
+export default () => <Route path='//packages/mock-package-3/examples/isolated/example3' component={view}/> 
 `;
 
 exports[`Generate readme page at the root level creates a readme page for the root level file 1`] = `
 import React from 'react';
+import { Route } from 'react-router-dom';
 import Component from '../../jest-fixture/README.md';
 import Wrapper from '../../jest-fixture/project-docs';
 
-export default () => (
+const view = () => (
   <Wrapper data={{"key":"readme","pagePath":"readme.js","pageTitle":"readme"}}>
       <Component />
   </Wrapper>
 );
+
+export default () => <Route path='/readme' component={view}/>
 `;
 
 exports[`readmes in the docs should generate a page for each child readme 1`] = `
 import React from 'react';
+import { Route } from 'react-router-dom';
 import Component from '../../../../../jest-fixture/docs/doc-3/readme.md';
 import Wrapper from '../../../../../jest-fixture/project-docs';
 
-export default () => (
+const view = () => (
   <Wrapper data={{"key":"docs","pagePath":"docs/doc-3/readme/index.js","pageTitle":"Doc 3"}}>
       <Component />
   </Wrapper>
 );
+
+export default () => <Route path='/docs/doc-3/readme' component={view}/>
 `;
 
 exports[`readmes in the docs should generate a page for each child readme 2`] = `
 import React from 'react';
+import { Route } from 'react-router-dom';
 import Component from '../../../../../../jest-fixture/docs/doc-3/doc-3-2/README.md';
 import Wrapper from '../../../../../../jest-fixture/project-docs';
 
-export default () => (
+const view = () => (
   <Wrapper data={{"key":"docs","pagePath":"docs/doc-3/doc-3-2/README/index.js","pageTitle":"Doc 3 2"}}>
       <Component />
   </Wrapper>
 );
+
+export default () => <Route path='/docs/doc-3/doc-3-2/README' component={view}/>
 `;

--- a/packages/website/src/bin/page-generator/templates/changelog/index.js
+++ b/packages/website/src/bin/page-generator/templates/changelog/index.js
@@ -1,4 +1,5 @@
 const outdent = require('outdent');
+const getRoutePath = require('../getRoute');
 
 /**
  * changelogTemplate - template for generating a changelog page
@@ -14,11 +15,14 @@ const changelogTemplate = (changelogPath, wrapperPath, data = {}) => outdent`
   import changelog from '!!raw-loader!${changelogPath}';
   import Wrapper from '${wrapperPath}';
 
-  export default () => (
+  const view = () => (
     <Wrapper data={${JSON.stringify(data)}}>
         {changelog}
     </Wrapper>
   );
+  export default () => <Route path='/${getRoutePath(
+    data.pagePath,
+  )}' component={view}/>
 `;
 
 module.exports = changelogTemplate;

--- a/packages/website/src/bin/page-generator/templates/example/index.js
+++ b/packages/website/src/bin/page-generator/templates/example/index.js
@@ -1,4 +1,5 @@
 const outdent = require('outdent');
+const getRoutePath = require('../getRoute');
 
 /**
  * exampleTemplate - template for an example page where the source code
@@ -12,13 +13,11 @@ const outdent = require('outdent');
  */
 const exampleTemplate = (componentPath, wrapperPath, data = {}) => outdent`
     import React from 'react';
-    import dynamic from 'next/dynamic';
     import fileContents from '!!raw-loader!${componentPath}';
     import Wrapper from '${wrapperPath}';
+    import * as Components from '${componentPath}';
     
-    const DynamicComponent = dynamic(import('${componentPath}')
-    .then(Components => {
-    return () => ( 
+    const view = () => ( 
     <Wrapper data={${JSON.stringify(data)}} fileContents={fileContents}>
           {
             [{ 
@@ -36,9 +35,10 @@ const exampleTemplate = (componentPath, wrapperPath, data = {}) => outdent`
             ]
           }
       </Wrapper>
-      )
-    }));
-    export default () => <DynamicComponent/>
+      );
+    export default () => <Route path='/${getRoutePath(
+      data.pagePath || data.isolatedPath,
+    )}' component={view}/> 
 `;
 
 module.exports = exampleTemplate;

--- a/packages/website/src/bin/page-generator/templates/getRoute.js
+++ b/packages/website/src/bin/page-generator/templates/getRoute.js
@@ -1,0 +1,6 @@
+module.exports = path => {
+  if (path.includes('index.js')) {
+    return path.replace('/index.js', '');
+  }
+  return path.replace('.js', '');
+};

--- a/packages/website/src/bin/page-generator/templates/single-component/index.js
+++ b/packages/website/src/bin/page-generator/templates/single-component/index.js
@@ -1,4 +1,5 @@
 const outdent = require('outdent');
+const getRoutePath = require('../getRoute');
 
 /**
  * basicSingleComponentTemplate - Template for a page that renders a single component
@@ -12,9 +13,12 @@ const basicSingleComponentTemplate = (wrapperPath, data = {}) => outdent`
     import React from 'react';
     import Wrapper from '${wrapperPath}';
 
-    export default () => (
+    const view = () => (
       <Wrapper data={${JSON.stringify(data)}} />
     );
+    export default () => <Route path='/${getRoutePath(
+      data.pagePath || data.isolatedPath,
+    )}' component={view}/>
 `;
 
 module.exports = basicSingleComponentTemplate;

--- a/packages/website/src/bin/page-generator/templates/wrapped-component/index.js
+++ b/packages/website/src/bin/page-generator/templates/wrapped-component/index.js
@@ -1,4 +1,5 @@
 const outdent = require('outdent');
+const getRoutePath = require('../getRoute');
 
 /**
  * wrappedComponentTemplate - template for a page containing one
@@ -17,14 +18,19 @@ const wrappedComponentTemplate = (
   data = {},
 ) => outdent`
   import React from 'react';
+  import { Route } from 'react-router-dom';
   import Component from '${componentPath}';
   import Wrapper from '${wrapperPath}';
 
-  export default () => (
+  const view = () => (
     <Wrapper data={${JSON.stringify(data)}}>
         <Component />
     </Wrapper>
   );
+  
+  export default () => <Route path='/${getRoutePath(
+    data.pagePath,
+  )}' component={view}/>
 `;
 
 module.exports = wrappedComponentTemplate;

--- a/packages/website/src/bin/page-generator/write-pages.integration.test.js
+++ b/packages/website/src/bin/page-generator/write-pages.integration.test.js
@@ -41,14 +41,17 @@ describe('Page templates', () => {
     assertNoAbsoluteImports(output);
     expect(output).toMatchInlineSnapshot(`
 "import React from 'react';
+import { Route } from 'react-router-dom';
 import Component from '../README.md';
 import Wrapper from '../wrappers/package-home';
 
-export default () => (
+const view = () => (
   <Wrapper data={{\\"pagePath\\":\\"output.js\\",\\"pageTitle\\":\\"My Package\\"}}>
       <Component />
   </Wrapper>
-);"
+);
+
+export default () => <Route path='/output' component={view}/>"
 `);
   });
 
@@ -67,9 +70,10 @@ export default () => (
 "import React from 'react';
 import Wrapper from '../wrappers/package-home';
 
-export default () => (
+const view = () => (
   <Wrapper data={{\\"pagePath\\":\\"output.js\\",\\"pageTitle\\":\\"My Package\\"}} />
-);"
+);
+export default () => <Route path='/output' component={view}/>"
 `);
   });
 
@@ -88,14 +92,17 @@ export default () => (
     assertNoAbsoluteImports(output);
     expect(output).toMatchInlineSnapshot(`
 "import React from 'react';
+import { Route } from 'react-router-dom';
 import Component from '../README.md';
 import Wrapper from '../wrappers/package-docs';
 
-export default () => (
+const view = () => (
   <Wrapper data={{\\"pagePath\\":\\"output.js\\",\\"pageTitle\\":\\"My Doc\\"}}>
       <Component />
   </Wrapper>
-);"
+);
+
+export default () => <Route path='/output' component={view}/>"
 `);
   });
 
@@ -141,9 +148,10 @@ export default () => (
 "import React from 'react';
 import Wrapper from '../wrappers/item-list';
 
-export default () => (
+const view = () => (
   <Wrapper data={{\\"pagePath\\":\\"output.js\\",\\"pageTitle\\":\\"\\",\\"pageType\\":\\"docs\\"}} />
-);"
+);
+export default () => <Route path='/output' component={view}/>"
 `);
   });
 
@@ -162,9 +170,10 @@ export default () => (
 "import React from 'react';
 import Wrapper from '../wrappers/item-list';
 
-export default () => (
+const view = () => (
   <Wrapper data={{\\"pagePath\\":\\"output.js\\",\\"pageTitle\\":\\"\\",\\"pageType\\":\\"examples\\"}} />
-);"
+);
+export default () => <Route path='/output' component={view}/>"
 `);
   });
 
@@ -183,14 +192,17 @@ export default () => (
     assertNoAbsoluteImports(output);
     expect(output).toMatchInlineSnapshot(`
 "import React from 'react';
+import { Route } from 'react-router-dom';
 import Component from '../README.md';
 import Wrapper from '../wrappers/project-docs';
 
-export default () => (
+const view = () => (
   <Wrapper data={{\\"pagePath\\":\\"output.js\\",\\"pageTitle\\":\\"My Doc\\"}}>
       <Component />
   </Wrapper>
-);"
+);
+
+export default () => <Route path='/output' component={view}/>"
 `);
   });
 });

--- a/packages/website/src/bin/parcel-server.js
+++ b/packages/website/src/bin/parcel-server.js
@@ -107,6 +107,8 @@ module.exports = async function createParcelServer({
       pageToBundles.set(pagePath, bundlePaths);
     }
 
+    console.log('entry', req.url, pagePath, bundlePaths.pageEntryAsset);
+
     res.render('page', {
       pageEntryAsset: bundlePaths.pageEntryAsset,
       scripts: bundlePaths.scripts.map(bundlePath =>

--- a/packages/website/src/components/breadcrumbs.tsx
+++ b/packages/website/src/components/breadcrumbs.tsx
@@ -1,10 +1,10 @@
 /* eslint-disable react/no-multi-comp */
-import * as React from 'react';
+import React from 'react';
 import titleCase from 'title-case';
 import Breadcrumbs, { BreadcrumbsItem } from '@atlaskit/breadcrumbs';
 import styled from '@emotion/styled';
 import { gridSize, math } from '@atlaskit/theme';
-import Link from 'next/link';
+import { NavLink } from 'react-router-dom';
 
 const Header = styled.div`
   left: 0;
@@ -27,7 +27,7 @@ const NextLink = React.forwardRef(
     ref: React.Ref<HTMLAnchorElement>,
   ) => {
     return (
-      <Link href={href}>
+      <NavLink to={href}>
         <a
           ref={ref}
           className={className}
@@ -36,7 +36,7 @@ const NextLink = React.forwardRef(
         >
           {children}
         </a>
-      </Link>
+      </NavLink>
     );
   },
 );

--- a/packages/website/src/components/code-example/code-view.tsx
+++ b/packages/website/src/components/code-example/code-view.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import { colors, gridSize, math, themed } from '@atlaskit/theme';
 import styled from '@emotion/styled';
 import Prism from 'prismjs';

--- a/packages/website/src/components/link-button.test.tsx
+++ b/packages/website/src/components/link-button.test.tsx
@@ -1,12 +1,16 @@
 import React from 'react';
 import { mount } from 'enzyme';
-import Link from 'next/link';
+import { Link, BrowserRouter as Router } from 'react-router-dom';
 
 import LinkButton from './link-button';
 
 describe('LinkButton', () => {
   it('should render an anchor', () => {
-    const wrapper = mount(<LinkButton href="/foo">Foo</LinkButton>);
+    const wrapper = mount(
+      <Router>
+        <LinkButton href="/foo">Foo</LinkButton>
+      </Router>,
+    );
 
     const anchor = wrapper.find('a');
     expect(anchor).toHaveLength(1);
@@ -14,15 +18,23 @@ describe('LinkButton', () => {
   });
 
   it('should render a next Link component', () => {
-    const wrapper = mount(<LinkButton href="/foo">Foo</LinkButton>);
+    const wrapper = mount(
+      <Router>
+        <LinkButton href="/foo">Foo</LinkButton>
+      </Router>,
+    );
 
     const link = wrapper.find(Link);
     expect(link).toHaveLength(1);
-    expect(link.prop('href')).toEqual('/foo');
+    expect(link.prop('to')).toEqual('/foo');
   });
 
   it('should not remount its contents across re-renders', () => {
-    const wrapper = mount(<LinkButton href="/foo">Foo</LinkButton>);
+    const wrapper = mount(
+      <Router>
+        <LinkButton href="/foo">Foo</LinkButton>
+      </Router>,
+    );
 
     const anchorBefore = wrapper.find('a').instance();
     const linkBefore = wrapper.find(Link).instance();

--- a/packages/website/src/components/link-button.tsx
+++ b/packages/website/src/components/link-button.tsx
@@ -6,10 +6,10 @@ Passes all props other than component directly into `@atlaskit/button`.
 See the [@atlaskit/button](https://atlaskit.atlassian.com/packages/core/button) docs for
 the options available to you.
 */
-import * as React from 'react';
+import React from 'react';
 
 import Button from '@atlaskit/button';
-import Link from 'next/link';
+import { NavLink } from 'react-router-dom';
 
 /** Note: Render components need to be defined standalone. Defining them inline will create a
  * new function reference each time and cause re-mounts on each render. */
@@ -21,9 +21,9 @@ const LinkButtonRenderComponent = ({
   href: string;
   children: React.ReactNode;
 }) => (
-  <Link href={href}>
-    <a {...rest}>{children}</a>
-  </Link>
+  <NavLink to={href} {...rest}>
+    {children}
+  </NavLink>
 );
 
 const LinkButton = (props: typeof Button) => (

--- a/packages/website/src/components/mdx/Heading.tsx
+++ b/packages/website/src/components/mdx/Heading.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import reactAddonsTextContent from 'react-addons-text-content';
 import snakeCase from 'lodash.snakecase';
 

--- a/packages/website/src/components/mdx/code/block.test.tsx
+++ b/packages/website/src/components/mdx/code/block.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import { shallow } from 'enzyme';
 import { AkCodeBlock } from '@atlaskit/code';
 

--- a/packages/website/src/components/mdx/code/block.tsx
+++ b/packages/website/src/components/mdx/code/block.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import { AkCodeBlock } from '@atlaskit/code';
 
 export type Props = {

--- a/packages/website/src/components/mdx/code/inline.tsx
+++ b/packages/website/src/components/mdx/code/inline.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import { AkCode } from '@atlaskit/code';
 
 export type Props = {

--- a/packages/website/src/components/mdx/index.tsx
+++ b/packages/website/src/components/mdx/index.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import Heading from './Heading';
 import Link from '../switch-link';
 import HorizontalRule from './HorizontalRule';

--- a/packages/website/src/components/meta-context.tsx
+++ b/packages/website/src/components/meta-context.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 
 export interface LinkObject {
   label: string;

--- a/packages/website/src/components/navigation-wrapper.tsx
+++ b/packages/website/src/components/navigation-wrapper.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import DocumentsIcon from '@atlaskit/icon/glyph/documents';
 import SearchIcon from '@atlaskit/icon/glyph/search';
 import {

--- a/packages/website/src/components/navigation/all-packages-nav-content.tsx
+++ b/packages/website/src/components/navigation/all-packages-nav-content.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {
   ContainerHeader,
   HeaderSection,

--- a/packages/website/src/components/navigation/docs-nav-content.tsx
+++ b/packages/website/src/components/navigation/docs-nav-content.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import { MenuSection } from '@atlaskit/navigation-next';
 import pageInfo from '../../pages-list';
 import NavHeader from './nav-header';

--- a/packages/website/src/components/navigation/link-component.tsx
+++ b/packages/website/src/components/navigation/link-component.tsx
@@ -1,7 +1,7 @@
 // Component that can be used as the component prop in nav items
 
-import * as React from 'react';
-import Link from 'next/link';
+import React from 'react';
+import { NavLink } from 'react-router-dom';
 
 export type Props = {
   className: string;
@@ -17,9 +17,9 @@ class LinkComponent extends React.Component<Props> {
     const { className, children, href } = this.props;
 
     return (
-      <Link href={href}>
-        <a className={className}>{children}</a>
-      </Link>
+      <NavLink to={href} className={className}>
+        {children}
+      </NavLink>
     );
   }
 }

--- a/packages/website/src/components/navigation/link-with-router.tsx
+++ b/packages/website/src/components/navigation/link-with-router.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import { withRouter } from 'next/router';
 import { Item } from '@atlaskit/navigation-next';
 import { colors } from '@atlaskit/theme';

--- a/packages/website/src/components/navigation/nav-header.tsx
+++ b/packages/website/src/components/navigation/nav-header.tsx
@@ -1,6 +1,6 @@
 // TODO:
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-import * as React from 'react';
+import React from 'react';
 import {
   ContainerHeader,
   HeaderSection,

--- a/packages/website/src/components/navigation/package-nav-content.tsx
+++ b/packages/website/src/components/navigation/package-nav-content.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 
 import { MenuSection, Separator, Group } from '@atlaskit/navigation-next';
 import titleCase from 'title-case';

--- a/packages/website/src/components/navigation/search-drawer.tsx
+++ b/packages/website/src/components/navigation/search-drawer.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {
   QuickSearch,
   ResultBase,

--- a/packages/website/src/components/navigation/tree-nav-content.tsx
+++ b/packages/website/src/components/navigation/tree-nav-content.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import styled from '@emotion/styled';
 import Tree from '@atlaskit/tree';
 import { colors } from '@atlaskit/theme';

--- a/packages/website/src/components/package-metadata.tsx
+++ b/packages/website/src/components/package-metadata.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import styled from '@emotion/styled';
 import GitUrlParse from 'git-url-parse';
 import titleCase from 'title-case';

--- a/packages/website/src/components/page-templates/documents-index.tsx
+++ b/packages/website/src/components/page-templates/documents-index.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import TableTree, {
   Headers,
   Header,

--- a/packages/website/src/components/page-title.tsx
+++ b/packages/website/src/components/page-title.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import Head from 'next/head';
 import Meta from './meta-context';
 

--- a/packages/website/src/components/panel.tsx
+++ b/packages/website/src/components/panel.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import styled, { keyframes } from 'styled-components';
 import { Props as IconProps } from '@atlaskit/icon/glyph/shortcut';
 import { colors, gridSize, math } from '@atlaskit/theme';

--- a/packages/website/src/components/switch-link.tsx
+++ b/packages/website/src/components/switch-link.tsx
@@ -1,22 +1,20 @@
-import * as React from 'react';
-import Link from 'next/link';
-import { withRouter, SingletonRouter } from 'next/router';
+import React from 'react';
+import { NavLink } from 'react-router-dom';
 import ShortcutIcon from '@atlaskit/icon/glyph/shortcut';
-import { PageStatusContext } from './common/page-status-context';
 
-const urlHasTrailingSlash = (router: SingletonRouter) => {
-  if (!router.asPath) {
-    return null;
-  }
-
-  const pathnameLength = router.pathname.length;
-  const pathnameIndex = router.asPath.indexOf(router.pathname);
-  if (pathnameIndex === -1) {
-    return null;
-  }
-
-  return router.asPath[pathnameIndex + pathnameLength] === '/';
-};
+// const urlHasTrailingSlash = (router: RouteComponentProps) => {
+//   // if (!router.asPath) {
+//   //   return null;
+//   // }
+//
+//   const pathnameLength = router.location.pathname.length;
+//   const pathnameIndex = router.asPath.indexOf(router.location.pathname);
+//   if (pathnameIndex === -1) {
+//     return null;
+//   }
+//
+//   return router.asPath[pathnameIndex + pathnameLength] === '/';
+// };
 
 /*
 This link component is designed to contextually be either a straight anchor
@@ -29,17 +27,14 @@ anchor, as it means you don't have to think about this problem space.
 export type Props = {
   href: string;
   includeShortcutIcon?: boolean; // default true - only has an effect for external links
-  passHref?: boolean; // for forwarding to a next/link
   children: (isExternal: boolean) => React.ReactChild;
-  router?: SingletonRouter;
+  // router?: RouteComponentProps;
 };
 
 const SwitchLink = ({
   href,
   children,
   includeShortcutIcon = true,
-  passHref,
-  router,
   ...rest
 }: Props) => {
   if (!href || href.indexOf('#') === 0) {
@@ -59,9 +54,9 @@ const SwitchLink = ({
     );
   }
 
-  let newHref = href.replace(/\.md$/, '');
-
-  const { convertedToDir = false } = React.useContext(PageStatusContext);
+  const newHref = href.replace(/\.md$/, '');
+  //
+  // const { convertedToDir = false } = React.useContext(PageStatusContext);
 
   /*
   Fun Fact: Next does not (and won't) handle relative links in exports.
@@ -77,35 +72,37 @@ const SwitchLink = ({
   `convertedToDir` is set to true when a README page has been converted to an
   indexed page, e.g. package home. In this case, we actually require the additional
   slash that next adds as part of its export so we can skip link surgery.
+
+  TODO: This may need to be changed as per how parcel works
   */
-  if (process.env.NODE_ENV === 'production' && !convertedToDir) {
-    if (newHref.startsWith('./')) {
-      newHref = newHref.replace('./', '../');
-    } else if (newHref.startsWith('../')) {
-      newHref = newHref.replace('../', '../../');
-    }
-  } else if (process.env.NODE_ENV !== 'production' && convertedToDir) {
-    /* In dev (non-export) mode, URLs work both with and without trailing slash URLs.
-     * Relative links in pages that have been converted to directories will only work when
-     * the URL contains a trailing slash, so modify the relative link if the current URL does
-     * not have one.
-     * This should ideally be fixed by enforcing trailing or non-trailing slashed URLs */
-    if (
-      newHref.startsWith('.') &&
-      router &&
-      urlHasTrailingSlash(router) === false
-    ) {
-      const urlSegments = router.pathname.split('/');
-      const lastUrlSegment = urlSegments[urlSegments.length - 1];
-      newHref = `./${lastUrlSegment}/${newHref}`;
-    }
-  }
+  // if (process.env.NODE_ENV === 'production' && !convertedToDir) {
+  //   if (newHref.startsWith('./')) {
+  //     newHref = newHref.replace('./', '../');
+  //   } else if (newHref.startsWith('../')) {
+  //     newHref = newHref.replace('../', '../../');
+  //   }
+  // } else if (process.env.NODE_ENV !== 'production' && convertedToDir) {
+  //   /* In dev (non-export) mode, URLs work both with and without trailing slash URLs.
+  //    * Relative links in pages that have been converted to directories will only work when
+  //    * the URL contains a trailing slash, so modify the relative link if the current URL does
+  //    * not have one.
+  //    * This should ideally be fixed by enforcing trailing or non-trailing slashed URLs */
+  //   if (
+  //     newHref.startsWith('.') &&
+  //     router &&
+  //     urlHasTrailingSlash(router) === false
+  //   ) {
+  //     const urlSegments = router.location.pathname.split('/');
+  //     const lastUrlSegment = urlSegments[urlSegments.length - 1];
+  //     newHref = `./${lastUrlSegment}/${newHref}`;
+  //   }
+  // }
 
   return (
-    <Link href={newHref} passHref={passHref}>
-      <a {...rest}>{children(false)}</a>
-    </Link>
+    <NavLink to={newHref} {...rest}>
+      {children(false)}
+    </NavLink>
   );
 };
 
-export default withRouter(SwitchLink as any) as typeof SwitchLink;
+export default SwitchLink;

--- a/yarn.lock
+++ b/yarn.lock
@@ -7364,6 +7364,18 @@ highlight.js@~9.12.0:
   resolved "https://packages.atlassian.com/api/npm/npm-remote/highlight.js/-/highlight.js-9.12.0.tgz#e6d9dbe57cbefe60751f02af336195870c90c01e"
   integrity sha1-5tnb5Xy+/mB1HwKvM2GVhwyQwB4=
 
+history@^4.7.2:
+  version "4.9.0"
+  resolved "https://registry.yarnpkg.com/history/-/history-4.9.0.tgz#84587c2068039ead8af769e9d6a6860a14fa1bca"
+  integrity sha512-H2DkjCjXf0Op9OAr6nJ56fcRkTSNrUiv41vNJ6IswJjif6wlpZK0BTfFbi7qK9dXLSYZxkq5lBsj3vUjlYBYZA==
+  dependencies:
+    "@babel/runtime" "^7.1.2"
+    loose-envify "^1.2.0"
+    resolve-pathname "^2.2.0"
+    tiny-invariant "^1.0.2"
+    tiny-warning "^1.0.0"
+    value-equal "^0.4.0"
+
 hmac-drbg@^1.0.0:
   version "1.0.1"
   resolved "https://packages.atlassian.com/api/npm/npm-remote/hmac-drbg/-/hmac-drbg-1.0.1.tgz#d2745701025a6c775a6c545793ed502fc0c649a1"
@@ -9123,7 +9135,7 @@ log-update@^1.0.2:
     ansi-escapes "^1.0.0"
     cli-cursor "^1.0.2"
 
-loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.3.1, loose-envify@^1.4.0:
+loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.2.0, loose-envify@^1.3.1, loose-envify@^1.4.0:
   version "1.4.0"
   resolved "https://packages.atlassian.com/api/npm/npm-remote/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
   integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
@@ -10543,6 +10555,13 @@ path-to-regexp@2.1.0:
   resolved "https://packages.atlassian.com/api/npm/npm-remote/path-to-regexp/-/path-to-regexp-2.1.0.tgz#7e30f9f5b134bd6a28ffc2e3ef1e47075ac5259b"
   integrity sha512-dZY7QPCPp5r9cnNuQ955mOv4ZFVDXY/yvqeV7Y1W2PJA3PEFcuow9xKFfJxbBj1pIjOAP+M2B4/7xubmykLrXw==
 
+path-to-regexp@^1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-1.7.0.tgz#59fde0f435badacba103a84e9d3bc64e96b9937d"
+  integrity sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=
+  dependencies:
+    isarray "0.0.1"
+
 path-type@^2.0.0:
   version "2.0.0"
   resolved "https://packages.atlassian.com/api/npm/npm-remote/path-type/-/path-type-2.0.0.tgz#f012ccb8415b7096fc2daa1054c3d72389594c73"
@@ -11312,6 +11331,31 @@ react-redux@^5.0.7:
     react-is "^16.6.0"
     react-lifecycles-compat "^3.0.0"
 
+react-router-dom@^4.3.1:
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-4.3.1.tgz#4c2619fc24c4fa87c9fd18f4fb4a43fe63fbd5c6"
+  integrity sha512-c/MlywfxDdCp7EnB7YfPMOfMD3tOtIjrQlj/CKfNMBxdmpJP8xcz5P/UAFn3JbnQCNUxsHyVVqllF9LhgVyFCA==
+  dependencies:
+    history "^4.7.2"
+    invariant "^2.2.4"
+    loose-envify "^1.3.1"
+    prop-types "^15.6.1"
+    react-router "^4.3.1"
+    warning "^4.0.1"
+
+react-router@^4.3.1:
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/react-router/-/react-router-4.3.1.tgz#aada4aef14c809cb2e686b05cee4742234506c4e"
+  integrity sha512-yrvL8AogDh2X42Dt9iknk4wF4V8bWREPirFfS9gLU1huk6qK41sg7Z/1S81jjTrGHxa3B8R3J6xIkDAA6CVarg==
+  dependencies:
+    history "^4.7.2"
+    hoist-non-react-statics "^2.5.0"
+    invariant "^2.2.4"
+    loose-envify "^1.3.1"
+    path-to-regexp "^1.7.0"
+    prop-types "^15.6.1"
+    warning "^4.0.1"
+
 react-scrolllock@^3.0.2:
   version "3.0.2"
   resolved "https://packages.atlassian.com/api/npm/npm-remote/react-scrolllock/-/react-scrolllock-3.0.2.tgz#b1607cb5f6b8a3bce02c78e7dfb1cbe564c1e992"
@@ -11894,6 +11938,11 @@ resolve-from@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-4.0.0.tgz#4abcd852ad32dd7baabfe9b40e00a36db5f392e6"
   integrity sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==
+
+resolve-pathname@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/resolve-pathname/-/resolve-pathname-2.2.0.tgz#7e9ae21ed815fd63ab189adeee64dc831eefa879"
+  integrity sha512-bAFz9ld18RzJfddgrO2e/0S2O81710++chRMUxHjXOYKF6jTAMrUNZrEZ1PvV0zlhfjidm08iRPdTLPno1FuRg==
 
 resolve-url@^0.2.1:
   version "0.2.1"
@@ -13158,10 +13207,20 @@ tiny-invariant@^0.0.3:
   resolved "https://packages.atlassian.com/api/npm/npm-remote/tiny-invariant/-/tiny-invariant-0.0.3.tgz#4c7283c950e290889e9e94f64d3586ec9156cf44"
   integrity sha512-SA2YwvDrCITM9fTvHTHRpq9W6L2fBsClbqm3maT5PZux4Z73SPPDYwJMtnoWh6WMgmCkJij/LaOlWiqJqFMK8g==
 
+tiny-invariant@^1.0.2:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/tiny-invariant/-/tiny-invariant-1.0.6.tgz#b3f9b38835e36a41c843a3b0907a5a7b3755de73"
+  integrity sha512-FOyLWWVjG+aC0UqG76V53yAWdXfH8bO6FNmyZOuUrzDzK8DI3/JRY25UD7+g49JWM1LXwymsKERB+DzI0dTEQA==
+
 tiny-invariant@^1.0.3:
   version "1.0.3"
   resolved "https://packages.atlassian.com/api/npm/npm-remote/tiny-invariant/-/tiny-invariant-1.0.3.tgz#91efaaa0269ccb6271f0296aeedb05fc3e067b7a"
   integrity sha512-ytQx8T4DL8PjlX53yYzcIC0WhIZbpR0p1qcYjw2pHu3w6UtgWwFJQ/02cnhOnBBhlFx/edUIfcagCaQSe3KMWg==
+
+tiny-warning@^1.0.0:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/tiny-warning/-/tiny-warning-1.0.3.tgz#94a30db453df4c643d0fd566060d60a875d84754"
+  integrity sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==
 
 title-case@^2.1.0, title-case@^2.1.1:
   version "2.1.1"
@@ -13842,6 +13901,11 @@ validator@^10.4.0:
   resolved "https://registry.yarnpkg.com/validator/-/validator-10.11.0.tgz#003108ea6e9a9874d31ccc9e5006856ccd76b228"
   integrity sha512-X/p3UZerAIsbBfN/IwahhYaBbY68EN/UQBWHtsbXGT5bfrH/p4NQzUCG1kF/rtKaNpnJ7jAu6NGTdSNtyNIXMw==
 
+value-equal@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/value-equal/-/value-equal-0.4.0.tgz#c5bdd2f54ee093c04839d71ce2e4758a6890abc7"
+  integrity sha512-x+cYdNnaA3CxvMaTX0INdTCN8m8aF2uY9BvEqmxuYp8bL09cs/kWVQPVGcA35fMktdOsP69IgU7wFj/61dJHEw==
+
 vary@~1.1.2:
   version "1.1.2"
   resolved "https://packages.atlassian.com/api/npm/npm-remote/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
@@ -13931,6 +13995,13 @@ warning@^3.0.0:
   version "3.0.0"
   resolved "https://packages.atlassian.com/api/npm/npm-remote/warning/-/warning-3.0.0.tgz#32e5377cb572de4ab04753bdf8821c01ed605b7c"
   integrity sha1-MuU3fLVy3kqwR1O9+IIcAe1gW3w=
+  dependencies:
+    loose-envify "^1.0.0"
+
+warning@^4.0.1:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/warning/-/warning-4.0.3.tgz#16e9e077eb8a86d6af7d64aa1e05fd85b4678ca3"
+  integrity sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==
   dependencies:
     loose-envify "^1.0.0"
 


### PR DESCRIPTION
In this PR I have added an approach for dynamic routing using parcel in brisk. Would like to get a review of the same to understand if it is appropriate before going deeper into it. Tested the approach using a testpackage.tsx page which is at `/testpackage` location. Also replaced all next/link, next/router dependencies to react router implementations.

The problems found at this stage is

- The /packages page breaks with some ReactComponent error. While debugging found that the pageEntryComponent value for packages.tsx is obtained as `{default: undefined, __esModule: true}`.
- The routing breaks due to the hyphen(-) in the filenames. 
- The parcel bundling is taking place only at the server. Nothing happens when we try to navigate to URLs using `<Link>`
- 